### PR TITLE
PRESS4-341 | added the jetpack plugin status

### DIFF
--- a/includes/Runtime.php
+++ b/includes/Runtime.php
@@ -57,6 +57,7 @@ class Runtime {
 				'restUrl'             => \esc_url_raw( \get_home_url() . '/index.php?rest_route=' ),
 				'restNonce'           => wp_create_nonce('wp_rest'),
 				'isWoocommerceActive' => is_plugin_active('woocommerce/woocommerce.php'),
+				'isJetpackBoostActive'    => is_plugin_active('jetpack-boost/jetpack-boost.php'),
 				'wpVersion'           => $wp_version,
 			)
 		);


### PR DESCRIPTION
https://jira.newfold.com/browse/PRESS4-341

need to add the code for checking whether jetpack is active or not. so that we can retrieve the status of jetpack plugin from runtime into Ecommerce module.