### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {} # No checkout or GitHub API usage; only derives branch name from GitHub env/context.
+    timeout-minutes: 30
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for reusable workflow to clone module and plugin repos (private).
+    timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -46,6 +48,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for reusable workflow to clone module and plugin repos (private).
+    timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,8 +6,9 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
@@ -17,8 +18,7 @@ jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    permissions: {} # No checkout or GitHub API usage; only derives branch name from GitHub env/context.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -31,9 +31,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for reusable workflow to clone module and plugin repos (private).
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -43,9 +43,9 @@ jobs:
   bluehost-dev:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for reusable workflow to clone module and plugin repos (private).
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {} # No checkout or GitHub API usage; derives repo name from github.repository context only.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -28,10 +30,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    permissions:
+      contents: write      # Required for reusable workflow to push coverage/GitHub Pages updates.
+      pull-requests: write # Required for reusable workflow to comment/post coverage on PRs.
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {} # No checkout or GitHub API usage; derives repo name from github.repository context only.
+    timeout-minutes: 30
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     permissions:
       contents: write      # Required for reusable workflow to push coverage/GitHub Pages updates.
       pull-requests: write # Required for reusable workflow to comment/post coverage on PRs.
+    timeout-minutes: 60
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/lint-checker-php.yml
+++ b/.github/workflows/lint-checker-php.yml
@@ -10,6 +10,10 @@ on:
       - '**.php'
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
@@ -18,6 +22,8 @@ jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo and compute PR diffs for PHPCS.
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint-checker-php.yml
+++ b/.github/workflows/lint-checker-php.yml
@@ -24,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required to clone the repo and compute PR diffs for PHPCS.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -21,10 +21,10 @@ jobs:
   # This job runs the newfold module-prep-release workflow for this module.
   prep-release:
     name: Prepare Release
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
+    permissions:
+      contents: write      # Required for reusable workflow to create release prep commits/branches.
+      pull-requests: write # Required for reusable workflow to open the release pull request.
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -25,6 +25,7 @@ jobs:
     permissions:
       contents: write      # Required for reusable workflow to create release prep commits/branches.
       pull-requests: write # Required for reusable workflow to open the release pull request.
+    timeout-minutes: 30
     with:
       module-repo: ${{ github.repository }}
       module-branch: 'main'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: read      # Required to clone the repo.
       id-token: write    # Required for npm trusted publishing (OIDC).
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # Node 24+ required: trusted publishing (OIDC) needs npm 11.5.1+; Node 22 ships npm 10

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,12 +5,16 @@ on:
       - created
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      id-token: write
+      contents: read      # Required to clone the repo.
+      id-token: write    # Required for npm trusted publishing (OIDC).
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # Node 24+ required: trusted publishing (OIDC) needs npm 11.5.1+; Node 22 ships npm 10

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -3,9 +3,16 @@ on:
   release:
     types:
       - created
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read      # Required to clone the repo.
+      packages: write     # Required to publish to GitHub Packages with NODE_AUTH_TOKEN (GITHUB_TOKEN).
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: read      # Required to clone the repo.
       packages: write     # Required to publish to GitHub Packages with NODE_AUTH_TOKEN (GITHUB_TOKEN).
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -12,6 +12,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # No default token scopes needed; repository dispatch uses WEBHOOK_TOKEN.
+    timeout-minutes: 30
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -3,10 +3,15 @@ on:
   release:
     types:
       - created
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # No default token scopes needed; repository dispatch uses WEBHOOK_TOKEN.
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 7 (`/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/brand-plugin-test-playwright.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/codecoverage-main.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/lint-checker-php.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/newfold-prep-release.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/npm-publish.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/publish-package.yml`, `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/satis-update.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `6d933c3` |
| Timeouts commit | `dbcef60` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/brand-plugin-test-playwright.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/codecoverage-main.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/lint-checker-php.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/npm-publish.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/publish-package.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/satis-update.yml` |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/satis-update.yml | 1 job was missing a scoped `permissions:` directive | webhook | `permissions: {}` [3] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/publish-package.yml | 1 job was missing a scoped `permissions:` directive | publish | `contents: read`, `packages: write` [3] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/npm-publish.yml | 1 job was missing a scoped `permissions:` directive (job already had permissions; workflow-level lock added — see notes below) | build | `contents: read`, `id-token: write` (now documented with inline justification comments) [3] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/lint-checker-php.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read` [3] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/brand-plugin-test-playwright.yml | 1 job was missing a scoped `permissions:` directive (two downstream jobs already had `contents: read`; clarified via comments and workflow-level lock) | setup | `permissions: {}` [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/brand-plugin-test-playwright.yml` :: `setup`: BEFORE `contents: read` -> AFTER `permissions: {}` -- No checkout and no GitHub API usage; branch name is derived from workflow environment/context only. -- [3] |
| 2 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/brand-plugin-test-playwright.yml` :: (workflow root): BEFORE `permissions: contents: read` -> AFTER `permissions: {}` plus job-level grants -- Default-deny at workflow scope with explicit job grants per least privilege. -- [3] |
| 3 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/codecoverage-main.yml` :: (workflow root): BEFORE `permissions: contents: read` -> AFTER `permissions: {}` plus explicit job grants -- Default-deny at workflow scope; `get-repo-name` needs no token scopes. -- [3] |
| 4 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/codecoverage-main.yml` :: `codecoverage`: BEFORE permission keys without inline rationale comments -> AFTER same scopes with aligned inline comments (`contents: write`, `pull-requests: write`) -- Documents why the reusable codecoverage workflow needs the passed `GITHUB_TOKEN`. -- [2] |
| 5 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/newfold-prep-release.yml` :: `prep-release`: BEFORE `permissions` preceding `uses:` -> AFTER `uses:` then `permissions:` -- Matches required job key ordering (permissions immediately after `uses:`). -- [3] |
| 6 | `/Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/newfold-prep-release.yml` :: `prep-release`: BEFORE permission keys without inline rationale comments -> AFTER same scopes with aligned inline comments (`contents: write`, `pull-requests: write`) -- Clarifies token needs for the reusable prep-release workflow. -- [2] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/satis-update.yml | webhook | `30` | Release webhook steps are quick; a low ceiling prevents a stuck runner from burning minutes indefinitely. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/publish-package.yml | publish | `30` | npm install/publish to GitHub Packages is typically short; bounded runtime limits accidental hangs. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/npm-publish.yml | build | `30` | Install, build, and OIDC publish should finish well under this cap unless registry/npm stalls. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/lint-checker-php.yml | phpcs | `30` | Composer install plus PHPCS on diff-only PHP changes should remain fast; timeout guards hung runners. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/codecoverage-main.yml | get-repo-name | `30` | Single-step metadata extraction; minimal expected runtime. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/codecoverage-main.yml | codecoverage | `60` | Reusable workflow runs multi-version PHP coverage and publishing steps; longer bound avoids false timeouts while still capping runaway jobs. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/brand-plugin-test-playwright.yml | setup | `30` | Branch extraction only; very small upper bound is sufficient. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/brand-plugin-test-playwright.yml | bluehost | `60` | Playwright-driven brand-plugin validation can be slower than lint jobs; moderate ceiling balances safety vs flakes. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/brand-plugin-test-playwright.yml | bluehost-dev | `60` | Same rationale as `bluehost`, against an alternate plugin branch with comparable integration cost. |
| /Users/jdesrosiers/Sites/GitHub/Organizations/newfold-labs/wp-module-runtime/.github/workflows/newfold-prep-release.yml | prep-release | `30` | Release prep automation should complete quickly; prevents endless waits if the reusable workflow misbehaves. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Reusable workflows under `newfold-labs/workflows` (`reusable-codecoverage.yml`, `module-plugin-test-playwright.yml`, `reusable-module-prep-release.yml`) were not fetched line-by-line in this pass; scopes follow documented token passthrough (`secrets: inherit` / `repo_token`) and intended behaviors described in comments, but confirm against upstream workflow changes if those repos evolve. |
| 2 | Third-party actions (`peter-evans/repository-dispatch`, `technote-space/get-diff-action`, etc.) were assessed by inputs and docs patterns; pin integrity relies on existing commit SHAs already in workflows. |


